### PR TITLE
Fixed cobol preprocessor source output of a new line in a content are a with a copy book immediately afterward.

### DIFF
--- a/rewrite-cobol/src/test/java/org/openrewrite/cobol/tree/cobol/CobolParserCopyTest.java
+++ b/rewrite-cobol/src/test/java/org/openrewrite/cobol/tree/cobol/CobolParserCopyTest.java
@@ -51,6 +51,29 @@ class CobolParserCopyTest extends CobolTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-cobol/issues/27")
+    @Test
+    void newLineInContentAreaBeforeCopyBook() {
+        rewriteRun(
+          cobolPostProcess(getNistResource("ISSUE_27.CBL"),
+            """
+              IDENTIFICATION DIVISION.
+              PROGRAM-ID . HELLO-WORLD.
+              DATA DIVISION.
+                  WORKING-STORAGE SECTION.
+                      77 X PIC 99.
+                      77 Y PIC 99.
+                      77 Z PIC 99.
+              PROCEDURE DIVISION.
+                  SET X TO 10.
+                  SET Y TO 25.
+                  ADD X Y GIVING Z.
+                  DISPLAY "X + Y = "Z.
+              STOP RUN.
+              """, true)
+        );
+    }
+
     @Test
     void sm101A() {
         rewriteRun(

--- a/rewrite-cobol/src/test/java/org/openrewrite/cobol/tree/preprocessor/CobolPreprocessorCopyBookTest.java
+++ b/rewrite-cobol/src/test/java/org/openrewrite/cobol/tree/preprocessor/CobolPreprocessorCopyBookTest.java
@@ -47,6 +47,14 @@ public class CobolPreprocessorCopyBookTest extends CobolTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-cobol/issues/27")
+    @Test
+    void newLineInContentAreaBeforeCopyBook() {
+        rewriteRun(
+          preprocessor(getNistResource("ISSUE_27.CBL"))
+        );
+    }
+
     @Test
     void altl1() {
         rewriteRun(

--- a/rewrite-cobol/src/test/resources/gov/nist/ISSUE_27.CBL
+++ b/rewrite-cobol/src/test/resources/gov/nist/ISSUE_27.CBL
@@ -1,0 +1,11 @@
+000000* Prevent trim
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID . HELLO-WORLD.
+       DATA DIVISION.
+       COPY ISSUE_27.
+       PROCEDURE DIVISION.
+           SET X TO 10.
+           SET Y TO 25.
+           ADD X Y GIVING Z.
+           DISPLAY "X + Y = "Z.
+       STOP RUN.

--- a/rewrite-cobol/src/test/resources/gov/nist/copybooks/ISSUE_27.CPY
+++ b/rewrite-cobol/src/test/resources/gov/nist/copybooks/ISSUE_27.CPY
@@ -1,0 +1,5 @@
+000000/
+           WORKING-STORAGE SECTION.
+               77 X PIC 99.
+               77 Y PIC 99.
+               77 Z PIC 99.


### PR DESCRIPTION
fixes #27