### PR TITLE
Preserve preprocessor statement declaration order.

### DIFF
--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolPreprocessorVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolPreprocessorVisitor.java
@@ -93,7 +93,7 @@ public class CobolPreprocessorVisitor<P> extends TreeVisitor<CobolPreprocessor, 
         CobolPreprocessor.CopyBook c = copyBook;
         c = c.withPrefix(visitSpace(c.getPrefix(), Space.Location.COPY_BOOK_PREFIX, p));
         c = c.withMarkers(visitMarkers(c.getMarkers(), p));
-        c = c.withAst(visit(c.getAst(), p));
+        c = c.withLst(ListUtils.map(c.getLst(), it -> visit(it, p)));
         c = c.withEof((CobolPreprocessor.Word) visit(c.getEof(), p));
         return c;
     }

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/CobolVisitor.java
@@ -4289,21 +4289,9 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
     }
 
     public Cobol visitWord(Cobol.Word word, P p) {
-        if (word.getCopyStatement() == null && word.getMarkers().findFirst(CopiedWord.class).isPresent()) {
-            return word;
-        }
-
         Cobol.Word w = word;
         // Preprocessed COBOL preservation.
-        if (w.getReplaceByStatement() != null) {
-            w = w.withReplaceByStatement((CobolPreprocessor.ReplaceByStatement) getCobolPreprocessorVisitor().visit(w.getReplaceByStatement(), p));
-            return w;
-        }
-
-        if (w.getReplaceOffStatement() != null) {
-            w = w.withReplaceOffStatement((CobolPreprocessor.ReplaceOffStatement) getCobolPreprocessorVisitor().visit(w.getReplaceOffStatement(), p));
-            return w;
-        }
+        w = w.withPreprocessorStatements(ListUtils.map(w.getPreprocessorStatements(), it -> getCobolPreprocessorVisitor().visit(it, p)));
 
         if (word.getReplacement() != null) {
             if (word.getReplacement().getType() == Replacement.Type.EQUAL || word.getReplacement().getType() == Replacement.Type.REDUCTIVE) {
@@ -4312,13 +4300,6 @@ public class CobolVisitor<P> extends TreeVisitor<Cobol, P> {
             }
             return w;
         }
-
-        if (w.getCopyStatement() != null) {
-            w = w.withCopyStatement((CobolPreprocessor.CopyStatement) getCobolPreprocessorVisitor().visit(w.getCopyStatement(), p));
-            return w;
-        }
-
-        w = w.withPreprocessorStatements(ListUtils.map(w.getPreprocessorStatements(), it -> getCobolPreprocessorVisitor().visit(it, p)));
 
         w = w.withPrefix(visitSpace(w.getPrefix(), Space.Location.WORD_PREFIX, p));
         w = w.withMarkers(visitMarkers(w.getMarkers(), p));

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/CopyBookParser.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/CopyBookParser.java
@@ -87,7 +87,7 @@ public class CopyBookParser implements Parser {
                         );
 
                         CobolPreprocessor.CompilationUnit preprocessedCU = parserVisitor.visitCompilationUnit(parser.compilationUnit());
-                        CobolPreprocessor parsedCopySource = preprocessedCU.getCobols().get(0);
+                        List<CobolPreprocessor> parsedCopySource = preprocessedCU.getCobols();
 
                         CobolPreprocessor.CopyBook copyBook = new CobolPreprocessor.CopyBook(
                                 randomId(),

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/PreprocessReplaceVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/PreprocessReplaceVisitor.java
@@ -387,9 +387,6 @@ public class PreprocessReplaceVisitor<P> extends CobolPreprocessorIsoVisitor<P> 
                                     toWord.getCobolWord().getWord(),
                                     null,
                                     null,
-                                    null,
-                                    null,
-                                    null,
                                     Collections.emptyList()
                             );
 
@@ -510,9 +507,6 @@ public class PreprocessReplaceVisitor<P> extends CobolPreprocessorIsoVisitor<P> 
                                 null,
                                 null,
                                 "",
-                                null,
-                                null,
-                                null,
                                 null,
                                 null,
                                 Collections.emptyList()

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/PreprocessReplaceVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/PreprocessReplaceVisitor.java
@@ -42,14 +42,15 @@ public class PreprocessReplaceVisitor<P> extends CobolPreprocessorIsoVisitor<P> 
                     FindReplaceableAreasVisitor findReplaceableAreasVisitor = new FindReplaceableAreasVisitor(entry.getKey());
 
                     //noinspection ConstantConditions
-                    CobolPreprocessor preprocessor = c.getCopyBook().getAst();
-                    findReplaceableAreasVisitor.visit(preprocessor, replaceWords);
-
-                    if (!replaceWords.isEmpty()) {
-                        ReplaceVisitor replaceVisitor = new ReplaceVisitor(replaceWords, entry.getValue());
-                        preprocessor = replaceVisitor.visit(preprocessor, new InMemoryExecutionContext(), getCursor());
-                        c = c.withCopyBook(c.getCopyBook().withAst(preprocessor));
-                    }
+                    c = c.withCopyBook(c.getCopyBook().withLst(ListUtils.map(c.getCopyBook().getLst(), preprocessor -> {
+                        findReplaceableAreasVisitor.visit(preprocessor, replaceWords);
+                        if (!replaceWords.isEmpty()) {
+                            ReplaceVisitor replaceVisitor = new ReplaceVisitor(replaceWords, entry.getValue());
+                            replaceWords.clear();
+                            return replaceVisitor.visit(preprocessor, new InMemoryExecutionContext(), getCursor());
+                        }
+                        return preprocessor;
+                    })));
                 }
             }
         }
@@ -151,7 +152,7 @@ public class PreprocessReplaceVisitor<P> extends CobolPreprocessorIsoVisitor<P> 
 
         @Override
         public CobolPreprocessor.CopyBook visitCopyBook(CobolPreprocessor.CopyBook copyBook, ExecutionContext executionContext) {
-            copyBook = copyBook.withAst(visit(copyBook.getAst(), executionContext));
+            copyBook = copyBook.withLst(ListUtils.map(copyBook.getLst(), it -> visit(it, executionContext)));
             return copyBook;
         }
 

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/cleanup/RemoveWithDebuggingMode.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/cleanup/RemoveWithDebuggingMode.java
@@ -11,6 +11,7 @@ import org.openrewrite.*;
 import org.openrewrite.cobol.CobolIsoVisitor;
 import org.openrewrite.cobol.format.RemoveWords;
 import org.openrewrite.cobol.format.ShiftSequenceAreas;
+import org.openrewrite.cobol.markers.CopiedWord;
 import org.openrewrite.cobol.tree.*;
 import org.openrewrite.internal.lang.Nullable;
 
@@ -79,8 +80,13 @@ public class RemoveWithDebuggingMode extends Recipe {
                 Cobol.SourceComputerDefinition s = super.visitSourceComputerDefinition(sourceComputerDefinition, executionContext);
                 if (s.getDebuggingMode() != null) {
                     // Do not change copied or replaced code until the transformations are understood.
-                    boolean isSupported = s.getDebuggingMode().stream().noneMatch(it ->
-                            it.getCopyStatement() != null || it.getReplacement() != null);
+                    boolean isSupported = true;
+                    for (Cobol.Word word : s.getDebuggingMode()) {
+                        if (word.getReplacement() != null || word.getMarkers().findFirst(CopiedWord.class).isPresent()) {
+                            isSupported = false;
+                            break;
+                        }
+                    }
 
                     if (isSupported) {
                         if (s.getComputerName().getCommentArea() != null && !s.getComputerName().getCommentArea().getPrefix().getWhitespace().isEmpty()) {

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/format/RemoveWords.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/format/RemoveWords.java
@@ -11,6 +11,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Incubating;
 import org.openrewrite.cobol.CobolIsoVisitor;
 import org.openrewrite.cobol.CobolPrinterUtils;
+import org.openrewrite.cobol.markers.CopiedWord;
 import org.openrewrite.cobol.search.FindWords;
 import org.openrewrite.cobol.tree.*;
 import org.openrewrite.internal.ListUtils;
@@ -39,7 +40,7 @@ public class RemoveWords extends CobolIsoVisitor<ExecutionContext> {
     public Cobol.Word visitWord(Cobol.Word word, ExecutionContext executionContext) {
         Cobol.Word w = super.visitWord(word, executionContext);
         if (removeWords.contains(w) && !w.getWord().trim().isEmpty()) {
-            if (word.getCopyStatement() != null || word.getReplacement() != null) {
+            if (word.getReplacement() != null || word.getMarkers().findFirst(CopiedWord.class).isPresent()) {
                 // The NIST test does not provide examples of these types of transformation, so it hasn't been implemented yet.
                 throw new UnsupportedOperationException("RemoveWords does not support changes on copied sources or replaced words.");
             }

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
@@ -6459,7 +6459,7 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                         null,
                         false,
                         null,
-                        new CobolPreprocessor.Word(EMPTY, Markers.EMPTY,
+                        singletonList(new CobolPreprocessor.Word(EMPTY, Markers.EMPTY,
                                 new Cobol.Word(
                                         EMPTY,
                                         Markers.EMPTY,
@@ -6473,7 +6473,7 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                                         null,
                                         null,
                                         null,
-                                        emptyList())),
+                                        emptyList()))),
                         new CobolPreprocessor.Word(EMPTY, Markers.EMPTY,
                                 new Cobol.Word(
                                         EMPTY,

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
@@ -82,12 +82,7 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
     private boolean inCopiedText;
 
     @Nullable
-    private CobolPreprocessor.CopyStatement currentCopy = null;
-
-    @Nullable
     private CopiedWord copiedWord = null;
-
-    boolean copyBookNotFound = false;
 
     private String replaceStartComment = null;
     private String replaceStopComment = null;
@@ -5593,9 +5588,6 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
         SequenceArea sequenceArea = null;
         IndicatorArea indicatorArea = null;
         CommentArea commentArea = null;
-        CobolPreprocessor.CopyStatement copyStatement = null;
-        CobolPreprocessor.ReplaceByStatement replaceByStatement = null;
-        CobolPreprocessor.ReplaceOffStatement replaceOffStatement = null;
         Replacement replacement = null;
         List<CobolPreprocessor> preprocessorStatements = new ArrayList<>();
 
@@ -5611,37 +5603,30 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 indicatorArea = (IndicatorArea) object;
             } else if (object instanceof CommentArea) {
                 commentArea = (CommentArea) object;
-            } else if (object instanceof CobolPreprocessor.CopyStatement) {
-                copyStatement = (CobolPreprocessor.CopyStatement) object;
-                if (copiedWord == null && !copyBookNotFound) {
-                    copiedWord = new CopiedWord(randomId(), copyStatement.getId().toString());
-                }
-            } else if (object instanceof CobolPreprocessor.ReplaceByStatement) {
-                replaceByStatement = (CobolPreprocessor.ReplaceByStatement) object;
-            } else if (object instanceof CobolPreprocessor.ReplaceOffStatement) {
-                replaceOffStatement = (CobolPreprocessor.ReplaceOffStatement) object;
             } else if (object instanceof Replacement) {
                 replacement = (Replacement) object;
-            } else if (object instanceof CobolPreprocessor.EjectStatement ||
+            } else if (object instanceof CobolPreprocessor.CopyStatement ||
+                    object instanceof CobolPreprocessor.ReplaceByStatement ||
+                    object instanceof CobolPreprocessor.ReplaceOffStatement ||
+                    object instanceof CobolPreprocessor.EjectStatement ||
                     object instanceof CobolPreprocessor.ExecStatement ||
                     object instanceof CobolPreprocessor.SkipStatement ||
                     object instanceof CobolPreprocessor.TitleStatement) {
+                if (object instanceof CobolPreprocessor.CopyStatement) {
+                    if (copiedWord == null && !((CobolPreprocessor.CopyStatement) object).getMarkers().findFirst(MissingCopyBook.class).isPresent()) {
+                        copiedWord = new CopiedWord(randomId(), ((CobolPreprocessor.CopyStatement) object).getId().toString());
+                    }
+                }
                 preprocessorStatements.add((CobolPreprocessor) object);
             }
         }
 
         // An unresolved copy book will not have any words from a copied source to add the statement to.
         // So the current copy is set to null on the next word that occurs in the LST.
-        if (copyBookNotFound) {
-            if (copyStatement == null) {
-                copyStatement = currentCopy;
-            }
-            currentCopy = null;
-            copyBookNotFound = false;
-        } else if (copiedWord != null) {
+        if (copiedWord != null) {
             markers = markers.addIfAbsent(copiedWord);
         }
-        Cobol.Word word = new Cobol.Word(
+        return new Cobol.Word(
                 prefix,
                 markers,
                 cobolLines,
@@ -5650,14 +5635,9 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                 indicatorArea,
                 text,
                 commentArea,
-                copyStatement,
-                replaceByStatement,
-                replaceOffStatement,
                 replacement,
                 preprocessorStatements.isEmpty() ? emptyList() : preprocessorStatements
         );
-        currentCopy = null;
-        return word;
     }
 
     @Override
@@ -6117,51 +6097,53 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
 
                 if (templateKeys.contains(contentArea)) {
                     if (replaceByStartComment.equals(contentArea)) {
-                        CobolPreprocessor.ReplaceByStatement replaceBy = getReplaceBy();
-                        objects.add(replaceBy);
+                        objects.add(getReplaceBy());
                     } else if (replaceStartComment.equals(contentArea)) {
                         replaceStartComment();
                     } else if (replaceAdditiveWhitespaceComment.equals(contentArea)) {
                         replaceAdditiveWhitespace();
                     } else if (replaceUuidComment.equals(contentArea)) {
-                        Replacement replace = getReplace();
-                        objects.add(replace);
+                        objects.add(getReplace());
                     } else if (replaceAdditiveTypeStartComment.equals(contentArea)) {
                         replaceAdditiveStartComment();
                     } else if (replaceAdditiveTypeStopComment.equals(contentArea)) {
                         replaceAdditiveStopComment();
                     } else if (replaceReductiveTypeStartComment.equals(contentArea)) {
-                        Replacement replaceReductiveType = getReplaceReductiveType();
-                        objects.add(replaceReductiveType);
+                        objects.add(getReplaceReductiveType());
                     } else if (replaceAddWordStartComment.equals(contentArea)) {
                         parseComment(replaceAddWordStartComment);
                         iterations = max;
                     } else if (replaceAddWordStopComment.equals(contentArea)) {
                         parseComment(replaceAddWordStopComment);
                     } else if (replaceOffStartComment.equals(contentArea)) {
-                        CobolPreprocessor.ReplaceOffStatement replaceOff = getReplaceOff();
-                        objects.add(replaceOff);
+                        objects.add(getReplaceOff());
                     } else if (copyStartComment.equals(contentArea)) {
                         copyStartComment();
                     } else if (copyUuidComment.equals(contentArea)) {
-                        copyUuidComment();
+                        CobolPreprocessor.CopyStatement copyStatement = copyUuidComment();
+                        int savedCursor = cursor;
+                        sequenceArea();
+                        indicatorArea();
+                        newLinePos = cursor + (source.substring(cursor).contains("\n") ? source.substring(cursor).indexOf("\n") : source.substring(cursor).length());
+                        endOfContentArea = cursor - cobolDialect.getColumns().getIndicatorArea() - 1 + cobolDialect.getColumns().getOtherArea();
+                        contentArea = source.substring(cursor, Math.min(newLinePos, endOfContentArea));
+                        if (copyBookNotFoundComment.equals(contentArea)) {
+                            copyStatement = copyBookNotFoundComment(copyStatement, lines);
+                            lines.clear();
+                        } else {
+                            cursor = savedCursor;
+                        }
+                        objects.add(copyStatement);
                     } else if (copyStopComment.equals(contentArea)) {
                         copyStopComment();
-                    } else if (copyBookNotFoundComment.equals(contentArea)) {
-                        copyBookNotFoundComment(lines);
-                        lines.clear();
                     } else if (ejectStartComment.equals(contentArea)) {
-                        CobolPreprocessor.EjectStatement eject = getEjectStatement();
-                        objects.add(eject);
+                        objects.add(getEjectStatement());
                     } else if (execStartComment.equals(contentArea)) {
-                        CobolPreprocessor.ExecStatement exec = getExecStatement();
-                        objects.add(exec);
+                        objects.add(getExecStatement());
                     } else if (skipStartComment.equals(contentArea)) {
-                        CobolPreprocessor.SkipStatement skip = getSkipStatement();
-                        objects.add(skip);
+                        objects.add(getSkipStatement());
                     } else if (titleStartComment.equals(contentArea)) {
-                        CobolPreprocessor.TitleStatement title = getTitleStatement();
-                        objects.add(title);
+                        objects.add(getTitleStatement());
                     }
                 } else {
                     cursor += contentArea.length();
@@ -6258,9 +6240,6 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
         }
 
         objects.add(new Continuation(Markers.EMPTY, continuations));
-        if (currentCopy != null) {
-            objects.add(currentCopy);
-        }
         return prefix;
     }
 
@@ -6395,9 +6374,6 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
             }
         }
 
-        if (currentCopy != null) {
-            objects.add(currentCopy);
-        }
         return prefix;
     }
 
@@ -6414,7 +6390,6 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
         removeTemplateCommentArea = true;
 
         // Reset copy info.
-        currentCopy = null;
         removeColumnMarkers = false;
         nextIndex = null;
     }
@@ -6433,23 +6408,21 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
         nextIndex = Integer.valueOf(numberOfSpaces.trim());
     }
 
-    private void copyUuidComment() {
+    private CobolPreprocessor.CopyStatement copyUuidComment() {
         parseComment(copyUuidComment);
 
         removeTemplateCommentArea = false;
 
         String uuid = getUuid();
-        currentCopy = copyMap.get(uuid.trim());
+        return copyMap.get(uuid.trim());
     }
 
-    private void copyBookNotFoundComment(List<CobolLine> lines) {
+    private CobolPreprocessor.CopyStatement copyBookNotFoundComment(CobolPreprocessor.CopyStatement copyStatement, List<CobolLine> lines) {
         parseComment(copyBookNotFoundComment);
-        copyBookNotFound = true;
-        assert currentCopy != null;
         // Rather than heavily modify the COBOL grammar, we inject a CopyBook into the CopyStatement.
         // The injected CopyBook is used to preserve the original source code.
-        currentCopy = currentCopy
-                .withMarkers(currentCopy.getMarkers().addIfAbsent(new MissingCopyBook(randomId())))
+        return copyStatement
+                .withMarkers(copyStatement.getMarkers().addIfAbsent(new MissingCopyBook(randomId())))
                 .withCopyBook(new CobolPreprocessor.CopyBook(
                         randomId(),
                         EMPTY,
@@ -6470,9 +6443,6 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                                         "",
                                         null,
                                         null,
-                                        null,
-                                        null,
-                                        null,
                                         emptyList()))),
                         new CobolPreprocessor.Word(EMPTY, Markers.EMPTY,
                                 new Cobol.Word(
@@ -6483,9 +6453,6 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
                                         null,
                                         null,
                                         "",
-                                        null,
-                                        null,
-                                        null,
                                         null,
                                         null,
                                         emptyList()))

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorOutputSourcePrinter.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorOutputSourcePrinter.java
@@ -170,7 +170,7 @@ public class CobolPreprocessorOutputSourcePrinter<P> extends CobolPreprocessorSo
     public CobolPreprocessor visitCopyBook(CobolPreprocessor.CopyBook copyBook, PrintOutputCapture<P> p) {
         visitSpace(copyBook.getPrefix(), Space.Location.COPY_BOOK_PREFIX, p);
         visitMarkers(copyBook.getMarkers(), p);
-        visit(copyBook.getAst(), p);
+        visit(copyBook.getLst(), p);
         visit(copyBook.getEof(), p);
         return copyBook;
     }

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorOutputSourcePrinter.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorOutputSourcePrinter.java
@@ -170,7 +170,16 @@ public class CobolPreprocessorOutputSourcePrinter<P> extends CobolPreprocessorSo
     public CobolPreprocessor visitCopyBook(CobolPreprocessor.CopyBook copyBook, PrintOutputCapture<P> p) {
         visitSpace(copyBook.getPrefix(), Space.Location.COPY_BOOK_PREFIX, p);
         visitMarkers(copyBook.getMarkers(), p);
-        visit(copyBook.getLst(), p);
+        for (CobolPreprocessor cobolPreprocessor : copyBook.getLst()) {
+            if (!(cobolPreprocessor instanceof CobolPreprocessor.CompilerOptions ||
+                    cobolPreprocessor instanceof CobolPreprocessor.EjectStatement ||
+                    cobolPreprocessor instanceof CobolPreprocessor.ExecStatement ||
+                    cobolPreprocessor instanceof CobolPreprocessor.SkipStatement ||
+                    cobolPreprocessor instanceof CobolPreprocessor.TitleStatement)) {
+                visit(cobolPreprocessor, p);
+            }
+        }
+
         visit(copyBook.getEof(), p);
         return copyBook;
     }

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorParserVisitor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorParserVisitor.java
@@ -137,7 +137,6 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
     @Override
     public Object visitCharData(CobolPreprocessorParser.CharDataContext ctx) {
         return new CobolPreprocessor.CharData(
-
                 EMPTY,
                 Markers.EMPTY,
                 convertAll(ctx.charDataLine())
@@ -153,7 +152,6 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
     @Override
     public Object visitCharDataLine(CobolPreprocessorParser.CharDataLineContext ctx) {
         return new CobolPreprocessor.CharDataLine(
-
                 EMPTY,
                 Markers.EMPTY,
                 convertAllList(ctx.cobolWord(), ctx.literal(), ctx.filename(), ctx.commentEntry(), ctx.TEXT(), ctx.DOT(), ctx.LPARENCHAR(), ctx.RPARENCHAR())
@@ -163,7 +161,6 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
     @Override
     public Object visitCharDataLineNoDot(CobolPreprocessorParser.CharDataLineNoDotContext ctx) {
         return new CobolPreprocessor.CharDataLine(
-
                 EMPTY,
                 Markers.EMPTY,
                 convertAllList(ctx.cobolWord(), ctx.literal(), ctx.filename(), ctx.commentEntry(), ctx.TEXT(), ctx.LPARENCHAR(), ctx.RPARENCHAR())
@@ -173,7 +170,6 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
     @Override
     public Object visitCharDataSql(CobolPreprocessorParser.CharDataSqlContext ctx) {
         return new CobolPreprocessor.CharDataSql(
-
                 EMPTY,
                 Markers.EMPTY,
                 convertAllList(ctx.charDataLine())
@@ -189,7 +185,6 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
     @Override
     public Object visitCommentEntry(CobolPreprocessorParser.CommentEntryContext ctx) {
         return new CobolPreprocessor.CommentEntry(
-
                 EMPTY,
                 Markers.EMPTY,
                 convertAll(ctx.COMMENTENTRYLINE())
@@ -199,7 +194,6 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
     @Override
     public Object visitCompilerOption(CobolPreprocessorParser.CompilerOptionContext ctx) {
         return new CobolPreprocessor.CompilerOption(
-
                 EMPTY,
                 Markers.EMPTY,
                 convertAllList(
@@ -510,7 +504,6 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
     @Override
     public Object visitCompilerXOpts(CobolPreprocessorParser.CompilerXOptsContext ctx) {
         return new CobolPreprocessor.CompilerXOpts(
-
                 EMPTY,
                 Markers.EMPTY,
                 (CobolPreprocessor.Word) visit(ctx.XOPTS()),
@@ -525,7 +518,6 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
         init();
 
         return new CobolPreprocessor.CompilationUnit(
-
                 path,
                 fileAttributes,
                 EMPTY,
@@ -557,7 +549,6 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
     @Override
     public Object visitCopySource(CobolPreprocessorParser.CopySourceContext ctx) {
         return new CobolPreprocessor.CopySource(
-
                 EMPTY,
                 Markers.EMPTY,
                 visit(ctx.literal(), ctx.cobolWord(), ctx.filename()),
@@ -667,7 +658,6 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
     @Override
     public Object visitPseudoText(CobolPreprocessorParser.PseudoTextContext ctx) {
         return new CobolPreprocessor.PseudoText(
-
                 EMPTY,
                 Markers.EMPTY,
                 (CobolPreprocessor.Word) visit(ctx.DOUBLEEQUALCHAR().get(0)),
@@ -777,9 +767,6 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
         SequenceArea sequenceArea = null;
         IndicatorArea indicatorArea = null;
         CommentArea commentArea = null;
-        CobolPreprocessor.CopyStatement copyStatement = null;
-        CobolPreprocessor.ReplaceByStatement replaceByStatement = null;
-        CobolPreprocessor.ReplaceOffStatement replaceOffStatement = null;
         Replacement replacement = null;
         List<CobolPreprocessor> preprocessorStatements = new ArrayList<>();
 
@@ -795,15 +782,12 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
                 indicatorArea = (IndicatorArea) object;
             } else if (object instanceof CommentArea) {
                 commentArea = (CommentArea) object;
-            } else if (object instanceof CobolPreprocessor.CopyStatement) {
-                copyStatement = (CobolPreprocessor.CopyStatement) object;
-            } else if (object instanceof CobolPreprocessor.ReplaceByStatement) {
-                replaceByStatement = (CobolPreprocessor.ReplaceByStatement) object;
-            } else if (object instanceof CobolPreprocessor.ReplaceOffStatement) {
-                replaceOffStatement = (CobolPreprocessor.ReplaceOffStatement) object;
             } else if (object instanceof Replacement) {
                 replacement = (Replacement) object;
-            } else if (object instanceof CobolPreprocessor.EjectStatement ||
+            } else if (object instanceof CobolPreprocessor.CopyStatement ||
+                    object instanceof CobolPreprocessor.ReplaceByStatement ||
+                    object instanceof CobolPreprocessor.ReplaceOffStatement ||
+                    object instanceof CobolPreprocessor.EjectStatement ||
                     object instanceof CobolPreprocessor.ExecStatement ||
                     object instanceof CobolPreprocessor.SkipStatement ||
                     object instanceof CobolPreprocessor.TitleStatement) {
@@ -812,11 +796,9 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
         }
 
         return new CobolPreprocessor.Word(
-
                 EMPTY,
                 Markers.EMPTY,
                 new Cobol.Word(
-
                         prefix,
                         Markers.EMPTY,
                         cobolLines,
@@ -825,9 +807,6 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
                         indicatorArea,
                         text,
                         commentArea,
-                        copyStatement,
-                        replaceByStatement,
-                        replaceOffStatement,
                         replacement,
                         preprocessorStatements.isEmpty() ? emptyList() : preprocessorStatements
                 )

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorPrinter.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorPrinter.java
@@ -27,7 +27,7 @@ public class CobolPreprocessorPrinter<P> extends CobolPreprocessorSourcePrinter<
     @Override
     public CobolPreprocessor visitCopyBook(CobolPreprocessor.CopyBook copyBook, PrintOutputCapture<P> p) {
         beforeSyntax(copyBook, Space.Location.COPY_BOOK_PREFIX, p);
-        visit(copyBook.getAst(), p);
+        visit(copyBook.getLst(), p);
         afterSyntax(copyBook, p);
         return copyBook;
     }

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorSourcePrinter.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorSourcePrinter.java
@@ -8,12 +8,14 @@ package org.openrewrite.cobol.internal;
 import org.openrewrite.Cursor;
 import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.cobol.CobolPreprocessorVisitor;
+import org.openrewrite.cobol.markers.CopiedWord;
 import org.openrewrite.cobol.tree.*;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.marker.Markers;
 
+import java.util.Optional;
 import java.util.function.UnaryOperator;
 
 /**
@@ -253,10 +255,21 @@ public class CobolPreprocessorSourcePrinter<P> extends CobolPreprocessorVisitor<
 
     @Override
     public CobolPreprocessor visitWord(CobolPreprocessor.Word word, PrintOutputCapture<P> p) {
-        visit(word.getCobolWord().getReplaceByStatement(), p);
-        visit(word.getCobolWord().getReplaceOffStatement(), p);
+        Optional<CopiedWord> copiedWord = word.getMarkers().findFirst(CopiedWord.class);
+        CobolPreprocessor.CopyStatement copyStatement = null;
+        for (CobolPreprocessor preprocessorStatement : word.getCobolWord().getPreprocessorStatements()) {
+            if (preprocessorStatement instanceof CobolPreprocessor.CopyStatement) {
+                copyStatement = (CobolPreprocessor.CopyStatement) preprocessorStatement;
+            } else {
+                cobolSourcePrinter.visit(preprocessorStatement, p);
+            }
+        }
 
-        if (word.getCobolWord().getReplacement() != null && word.getCobolWord().getCopyStatement() == null) {
+        if (copyStatement == null && copiedWord.isPresent()) {
+            return word;
+        }
+
+        if (word.getCobolWord().getReplacement() != null) {
             if (word.getCobolWord().getReplacement().getType() == Replacement.Type.EQUAL) {
                 Replacement.OriginalWord originalWord = word.getCobolWord().getReplacement().getOriginalWords().get(0);
                 cobolSourcePrinter.visitWord(originalWord.getOriginal(), p);
@@ -283,9 +296,9 @@ public class CobolPreprocessorSourcePrinter<P> extends CobolPreprocessorVisitor<
         }
 
         // The COBOL word is a product of a copy statement.
-        if (word.getCobolWord().getCopyStatement() != null) {
+        if (copyStatement != null) {
             // Print the original Copy Statement in place of the first word from the copied source.
-            visit(word.getCobolWord().getCopyStatement(), p);
+            visit(copyStatement, p);
 
             // Do not print the AST for the copied source.
             return word;

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolSourcePrinter.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/internal/CobolSourcePrinter.java
@@ -17,6 +17,7 @@ import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.marker.Markers;
 
+import java.util.Optional;
 import java.util.function.UnaryOperator;
 
 /**
@@ -4315,14 +4316,21 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
 
     @Override
     public Cobol visitWord(Cobol.Word word, PrintOutputCapture<P> p) {
-        if (word.getCopyStatement() == null && word.getMarkers().findFirst(CopiedWord.class).isPresent()) {
+        Optional<CopiedWord> copiedWord = word.getMarkers().findFirst(CopiedWord.class);
+        CobolPreprocessor.CopyStatement copyStatement = null;
+        for (CobolPreprocessor preprocessorStatement : word.getPreprocessorStatements()) {
+            if (preprocessorStatement instanceof CobolPreprocessor.CopyStatement) {
+                copyStatement = (CobolPreprocessor.CopyStatement) preprocessorStatement;
+            } else {
+                getCobolPreprocessorVisitor().visit(preprocessorStatement, p);
+            }
+        }
+
+        if (copyStatement == null && copiedWord.isPresent()) {
             return word;
         }
 
-        getCobolPreprocessorVisitor().visit(word.getReplaceByStatement(), p);
-        getCobolPreprocessorVisitor().visit(word.getReplaceOffStatement(), p);
-
-        if (word.getReplacement() != null && word.getCopyStatement() == null) {
+        if (word.getReplacement() != null && copyStatement == null) {
             if (word.getReplacement().getType() == Replacement.Type.EQUAL) {
                 int startLength = p.getOut().length();
                 Replacement.OriginalWord originalWord = word.getReplacement().getOriginalWords().get(0);
@@ -4353,14 +4361,12 @@ public class CobolSourcePrinter<P> extends CobolVisitor<PrintOutputCapture<P>> {
         }
 
         // The COBOL word is a product of a copy statement.
-        if (word.getCopyStatement() != null) {
-            getCobolPreprocessorVisitor().visit(word.getCopyStatement(), p);
-            if (!word.getCopyStatement().getMarkers().findFirst(MissingCopyBook.class).isPresent()) {
+        if (copyStatement != null) {
+            getCobolPreprocessorVisitor().visit(copyStatement, p);
+            if (!copyStatement.getMarkers().findFirst(MissingCopyBook.class).isPresent()) {
                 return word;
             }
         }
-
-        getCobolPreprocessorVisitor().visit(word.getPreprocessorStatements(), p);
 
         if (printColumns) {
             if (word.getLines() != null) {

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/search/FindCopyBook.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/search/FindCopyBook.java
@@ -13,6 +13,7 @@ import org.openrewrite.cobol.markers.MissingCopyBook;
 import org.openrewrite.cobol.table.CopyBookSource;
 import org.openrewrite.cobol.tree.Cobol;
 import org.openrewrite.cobol.tree.CobolPreprocessor;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.SearchResult;
 
@@ -44,37 +45,43 @@ public class FindCopyBook extends Recipe {
 
             @Override
             public Cobol.Word visitWord(Cobol.Word word, ExecutionContext executionContext) {
-                if (word.getCopyStatement() != null) {
-                    if (word.getCopyStatement().getMarkers().findFirst(MissingCopyBook.class).isPresent()) {
+                Cobol.Word w = super.visitWord(word, executionContext);
+                w = w.withPreprocessorStatements(ListUtils.map(w.getPreprocessorStatements(), ps -> {
+                    if (ps instanceof CobolPreprocessor.CopyStatement) {
+                        CobolPreprocessor.CopyStatement copyStatement = (CobolPreprocessor.CopyStatement) ps;
+                        if (copyStatement.getMarkers().findFirst(MissingCopyBook.class).isPresent()) {
                             //noinspection DataFlowIssue
                             copyBookSource.insertRow(executionContext,
                                     new CopyBookSource.Row(
                                             getCursor().firstEnclosing(Cobol.CompilationUnit.class).getSourcePath().toString(),
-                                            word.getCopyStatement().getCopySource().getName().getCobolWord().getWord(),
+                                            copyStatement.getCopySource().getName().getCobolWord().getWord(),
                                             "",
                                             CopyBookSource.ResolutionStatus.MISSING_SOURCE,
                                             ""));
-                            return word.withCopyStatement(word.getCopyStatement().withCopySource(
-                                    word.getCopyStatement().getCopySource().withName(
-                                            SearchResult.found(word.getCopyStatement().getCopySource().getName()))));
-                    } else {
-                        if (copyBookName == null || copyBookName.isEmpty() || copyBookName.equals(word.getCopyStatement().getCopySource().getName().getCobolWord().getWord())) {
-                            CobolPreprocessor.CopyStatement updated = word.getCopyStatement().withCopySource(word.getCopyStatement().getCopySource().withName(
-                                    SearchResult.found(word.getCopyStatement().getCopySource().getName(), null)));
-                            boolean copySourceResolved = word.getCopyStatement().getCopyBook() != null;
-                            //noinspection DataFlowIssue
-                            copyBookSource.insertRow(executionContext,
-                                    new CopyBookSource.Row(
-                                            getCursor().firstEnclosing(Cobol.CompilationUnit.class).getSourcePath().toString(),
-                                            word.getCopyStatement().getCopySource().getName().getCobolWord().getWord(),
-                                            copySourceResolved ? word.getCopyStatement().getCopyBook().getSourcePath().toString() : "",
-                                            copySourceResolved ? CopyBookSource.ResolutionStatus.RESOLVED : CopyBookSource.ResolutionStatus.NO_SOURCE_PATH,
-                                            word.getWord()));
-                            return word.withCopyStatement(updated);
+                            return copyStatement.withCopySource(
+                                    copyStatement.getCopySource().withName(
+                                            SearchResult.found(copyStatement.getCopySource().getName())));
+                        } else {
+                            if (copyBookName == null || copyBookName.isEmpty() || copyBookName.equals(copyStatement.getCopySource().getName().getCobolWord().getWord())) {
+                                CobolPreprocessor.CopyStatement updated = copyStatement.withCopySource(copyStatement.getCopySource().withName(
+                                        SearchResult.found(copyStatement.getCopySource().getName(), null)));
+                                boolean copySourceResolved = copyStatement.getCopyBook() != null;
+                                //noinspection DataFlowIssue
+                                copyBookSource.insertRow(executionContext,
+                                        new CopyBookSource.Row(
+                                                getCursor().firstEnclosing(Cobol.CompilationUnit.class).getSourcePath().toString(),
+                                                copyStatement.getCopySource().getName().getCobolWord().getWord(),
+                                                copySourceResolved ? copyStatement.getCopyBook().getSourcePath().toString() : "",
+                                                copySourceResolved ? CopyBookSource.ResolutionStatus.RESOLVED : CopyBookSource.ResolutionStatus.NO_SOURCE_PATH,
+                                                word.getWord()));
+                                return updated;
+                            }
                         }
                     }
-                }
-                return super.visitWord(word, executionContext);
+                    return ps;
+                }));
+
+                return w;
             }
         });
     }

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/search/FindWord.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/search/FindWord.java
@@ -13,6 +13,7 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.cobol.CobolPreprocessorIsoVisitor;
 import org.openrewrite.cobol.NameVisitor;
+import org.openrewrite.cobol.markers.CopiedWord;
 import org.openrewrite.cobol.tree.Cobol;
 import org.openrewrite.cobol.tree.CobolPreprocessor;
 import org.openrewrite.cobol.tree.Replacement;
@@ -20,6 +21,7 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.SearchResult;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 @EqualsAndHashCode(callSuper = true)
@@ -68,14 +70,15 @@ public class FindWord extends Recipe {
         @Override
         public Cobol.Word visitWord(Cobol.Word word, ExecutionContext executionContext) {
             Cobol.Word w = super.visitWord(word, executionContext);
-            // Preprocessed COBOL preservation.
-            if (w.getReplaceByStatement() != null) {
-                w = w.withReplaceByStatement((CobolPreprocessor.ReplaceByStatement) preprocessorSearch.visit(w.getReplaceByStatement(), executionContext));
-                return w;
-            }
+            AtomicBoolean hasCopyStatement = new AtomicBoolean(false);
+            w = w.withPreprocessorStatements(ListUtils.map(w.getPreprocessorStatements(), it -> {
+                if (it instanceof CobolPreprocessor.CopyStatement && !hasCopyStatement.get()) {
+                    hasCopyStatement.set(true);
+                }
+                return preprocessorSearch.visit(it, executionContext);
+            }));
 
-            if (w.getReplaceOffStatement() != null) {
-                w = w.withReplaceOffStatement((CobolPreprocessor.ReplaceOffStatement) preprocessorSearch.visit(w.getReplaceOffStatement(), executionContext));
+            if (hasCopyStatement.get() || w.getMarkers().findFirst(CopiedWord.class).isPresent()) {
                 return w;
             }
 
@@ -84,11 +87,6 @@ public class FindWord extends Recipe {
                     w = w.withReplacement(w.getReplacement().withOriginalWords(
                             ListUtils.map(w.getReplacement().getOriginalWords(), it -> it.withOriginal(visitAndCast(it.getOriginal(), executionContext)))));
                 }
-                return w;
-            }
-
-            if (w.getCopyStatement() != null) {
-                w = w.withCopyStatement((CobolPreprocessor.CopyStatement) preprocessorSearch.visit(w.getCopyStatement(), executionContext));
                 return w;
             }
 

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/search/UsesCopyBook.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/search/UsesCopyBook.java
@@ -46,8 +46,13 @@ public class UsesCopyBook extends CobolIsoVisitor<ExecutionContext> {
                 public Cobol.Word visitWord(Cobol.Word word, List<CobolPreprocessor.CopySource> copySources) {
                     Cobol.Word w = super.visitWord(word, copySources);
                     if (copySources.isEmpty()) {
-                        if (w.getCopyStatement() != null && (bookName == null || bookName.isEmpty() || bookName.equals(w.getCopyStatement().getCopySource().getName().getCobolWord().getWord()))) {
-                            copySources.add(w.getCopyStatement().getCopySource());
+                        for (CobolPreprocessor preprocessorStatement : w.getPreprocessorStatements()) {
+                            if (preprocessorStatement instanceof CobolPreprocessor.CopyStatement) {
+                                CobolPreprocessor.CopyStatement copyStatement = (CobolPreprocessor.CopyStatement) preprocessorStatement;
+                                if (bookName == null || bookName.isEmpty() || bookName.equals(copyStatement.getCopySource().getName().getCobolWord().getWord())) {
+                                    copySources.add(copyStatement.getCopySource());
+                                }
+                            }
                         }
                     }
                     return w;

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Cobol.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/Cobol.java
@@ -932,16 +932,6 @@ public interface Cobol extends Tree {
         @Nullable
         CommentArea commentArea;
 
-        // Preprocessor elements
-        @Nullable
-        CobolPreprocessor.CopyStatement copyStatement;
-
-        @Nullable
-        CobolPreprocessor.ReplaceByStatement replaceByStatement;
-
-        @Nullable
-        CobolPreprocessor.ReplaceOffStatement replaceOffStatement;
-
         @Nullable
         Replacement replacement;
 

--- a/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/CobolPreprocessor.java
+++ b/rewrite-cobol/src/main/java/org/openrewrite/cobol/tree/CobolPreprocessor.java
@@ -250,7 +250,7 @@ public interface CobolPreprocessor extends Tree {
             return withCharsetName(charset.name());
         }
 
-        CobolPreprocessor ast;
+        List<CobolPreprocessor> lst;
         CobolPreprocessor.Word eof;
 
         @Override

--- a/rewrite-cobol/src/test/java/org/openrewrite/cobol/tree/cobol/CobolParserCopyTest.java
+++ b/rewrite-cobol/src/test/java/org/openrewrite/cobol/tree/cobol/CobolParserCopyTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.cobol.CobolTest;
 
-import static org.openrewrite.cobol.Assertions.cobol;
 import static org.openrewrite.cobol.Assertions.cobolPostProcess;
 
 class CobolParserCopyTest extends CobolTest {
@@ -34,9 +33,56 @@ class CobolParserCopyTest extends CobolTest {
 
     @Issue("https://github.com/openrewrite/rewrite-cobol/issues/47")
     @Test
-    void preprocessorDirective() {
+    void mixedOrderPreprocessorDirectives() {
         rewriteRun(
-          cobol(
+          cobolPostProcess(
+            """
+              000000 IDENTIFICATION DIVISION.                                         *
+                         PROGRAM-ID.                                                  *
+                             IC109A.                                                  *
+                         DATA DIVISION.                                               *
+                         LINKAGE SECTION.                                             *
+                         01  GRP-01.                                                  *
+                             SKIP2                                                    *
+                             COPY PREPROCESSOR_DIRECTIVE.                             *
+                    /                                                                 *
+                             EJECT
+                             COPY PREPROCESSOR_DIRECTIVE.                             *
+                             SKIP3
+                             02  SPECIAL-FLAGS.                                       *
+                                 03  DN7 PICTURE X.                                   *
+                                 03  DN8 PICTURE X.                                   *
+                                 03  DN9 PICTURE X.                                   *
+              """,
+            """
+              IDENTIFICATION DIVISION.
+                  PROGRAM-ID.
+                      IC109A.
+                  DATA DIVISION.
+                  LINKAGE SECTION.
+                  01  GRP-01.
+                      02  SUB-CALLED.
+                          03  DN1  PICTURE X(6).
+                          03  DN2  PICTURE X(6).
+                          03  DN3  PICTURE X(6).
+                      02  SUB-CALLED.
+                          03  DN1  PICTURE X(6).
+                          03  DN2  PICTURE X(6).
+                          03  DN3  PICTURE X(6).
+                      02  SPECIAL-FLAGS.
+                          03  DN7 PICTURE X.
+                          03  DN8 PICTURE X.
+                          03  DN9 PICTURE X.
+              """, true
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-cobol/issues/47")
+    @Test
+    void preprocessorDirectiveInCopiedSource() {
+        rewriteRun(
+          cobolPostProcess(
             """
               000000 IDENTIFICATION DIVISION.                                         *
                          PROGRAM-ID.                                                  *
@@ -59,6 +105,34 @@ class CobolParserCopyTest extends CobolTest {
                                  03  DN7 PICTURE X.                                   *
                                  03  DN8 PICTURE X.                                   *
                                  03  DN9 PICTURE X.                                   *
+              """,
+            """
+              IDENTIFICATION DIVISION.
+                  PROGRAM-ID.
+                      IC109A.
+                  DATA DIVISION.
+                  LINKAGE SECTION.
+                  01  GRP-01.
+                      02  SUB-CALLED.
+                          03  DN1  PICTURE X(6).
+                          03  DN2  PICTURE X(6).
+                          03  DN3  PICTURE X(6).
+                      02  SUB-CALLED.
+                          03  DN1  PICTURE X(6).
+                          03  DN2  PICTURE X(6).
+                          03  DN3  PICTURE X(6).
+                      02  SUB-CALLED.
+                          03  DN1  PICTURE X(6).
+                          03  DN2  PICTURE X(6).
+                          03  DN3  PICTURE X(6).
+                      02  SUB-CALLED.
+                          03  DN1  PICTURE X(6).
+                          03  DN2  PICTURE X(6).
+                          03  DN3  PICTURE X(6).
+                      02  SPECIAL-FLAGS.
+                          03  DN7 PICTURE X.
+                          03  DN8 PICTURE X.
+                          03  DN9 PICTURE X.
               """, true
           )
         );

--- a/rewrite-cobol/src/test/java/org/openrewrite/cobol/tree/cobol/CobolParserCopyTest.java
+++ b/rewrite-cobol/src/test/java/org/openrewrite/cobol/tree/cobol/CobolParserCopyTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
 import org.openrewrite.cobol.CobolTest;
 
+import static org.openrewrite.cobol.Assertions.cobol;
 import static org.openrewrite.cobol.Assertions.cobolPostProcess;
 
 class CobolParserCopyTest extends CobolTest {
@@ -28,6 +29,38 @@ class CobolParserCopyTest extends CobolTest {
                      COPY MISSING-COPYBOOK.
                      01  DUMMY-RECORD PICTURE X(120).
               """)
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-cobol/issues/47")
+    @Test
+    void preprocessorDirective() {
+        rewriteRun(
+          cobol(
+            """
+              000000 IDENTIFICATION DIVISION.                                         *
+                         PROGRAM-ID.                                                  *
+                             IC109A.                                                  *
+                         DATA DIVISION.                                               *
+                         LINKAGE SECTION.                                             *
+                         01  GRP-01.                                                  *
+                             COPY PREPROCESSOR_DIRECTIVE.                             *
+                    /                                                                 *
+                             COPY PREPROCESSOR_DIRECTIVE.                             *
+                    /                                                                 *
+                             02  SUB-CALLED.                                          *
+                                 03  DN1  PICTURE X(6).                               *
+                                 03  DN2  PICTURE X(6).                               *
+                                 03  DN3  PICTURE X(6).                               *
+                                                                                      *
+                             COPY PREPROCESSOR_DIRECTIVE.                             *
+                    /                                                                 *
+                             02  SPECIAL-FLAGS.                                       *
+                                 03  DN7 PICTURE X.                                   *
+                                 03  DN8 PICTURE X.                                   *
+                                 03  DN9 PICTURE X.                                   *
+              """, true
+          )
         );
     }
 

--- a/rewrite-cobol/src/test/resources/gov/nist/copybooks/PREPROCESSOR_DIRECTIVE.CPY
+++ b/rewrite-cobol/src/test/resources/gov/nist/copybooks/PREPROCESSOR_DIRECTIVE.CPY
@@ -1,0 +1,5 @@
+000000         SKIP3
+               02  SUB-CALLED.
+                   03  DN1  PICTURE X(6).
+                   03  DN2  PICTURE X(6).
+                   03  DN3  PICTURE X(6).


### PR DESCRIPTION
Changes:
- CopyBooks will preserve preprocessor statements and the copied COBOL source elements.
- COBOL tree will preserve the declaration order of preprocessor statements.
- Source printers will not print processor elements from copied sources.

fixes #47
