### PR TITLE
Polish.

### DIFF
--- a/src/main/java/org/openrewrite/cobol/PreprocessReplaceVisitor.java
+++ b/src/main/java/org/openrewrite/cobol/PreprocessReplaceVisitor.java
@@ -14,7 +14,6 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.marker.Markers;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.cobol.tree.Space.EMPTY;
@@ -28,10 +27,13 @@ public class PreprocessReplaceVisitor<P> extends CobolPreprocessorIsoVisitor<P> 
         CobolPreprocessor.CopyStatement c = super.visitCopyStatement(copyStatement, p);
 
         if (c.getCopybook() != null) {
-            List<CobolPreprocessor.ReplacingPhrase> phrases = c.getCobols().stream()
-                    .filter(is -> is instanceof CobolPreprocessor.ReplacingPhrase)
-                    .map(it -> (CobolPreprocessor.ReplacingPhrase) it)
-                    .collect(Collectors.toList());
+            List<CobolPreprocessor.ReplacingPhrase> phrases = new ArrayList<>();
+            for (CobolPreprocessor is : c.getCobols()) {
+                if (is instanceof CobolPreprocessor.ReplacingPhrase) {
+                    CobolPreprocessor.ReplacingPhrase replacingPhrase = (CobolPreprocessor.ReplacingPhrase) is;
+                    phrases.add(replacingPhrase);
+                }
+            }
 
             if (!phrases.isEmpty()) {
                 Map<List<CobolPreprocessor.Word>, List<CobolPreprocessor.Word>> replacements = new LinkedHashMap<>();

--- a/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
+++ b/src/main/java/org/openrewrite/cobol/internal/CobolParserVisitor.java
@@ -6002,7 +6002,7 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
         for (T tree : trees) {
             converted.add(convert.apply(tree));
         }
-        return converted;
+        return converted.isEmpty() ? emptyList() : converted;
     }
 
     @SafeVarargs
@@ -6039,7 +6039,7 @@ public class CobolParserVisitor extends CobolBaseVisitor<Object> {
         for (ParseTree pt : parseTrees) {
             parsed.add((Cobol) visit(pt));
         }
-        return parsed;
+        return parsed.isEmpty() ? emptyList() : parsed;
     }
 
     /**

--- a/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorParserVisitor.java
+++ b/src/main/java/org/openrewrite/cobol/internal/CobolPreprocessorParserVisitor.java
@@ -19,7 +19,6 @@ import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -872,16 +871,21 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
         for (T tree : trees) {
             converted.add(convert.apply(tree));
         }
-        return converted;
+        return converted.isEmpty() ? emptyList() : converted;
     }
 
     @SafeVarargs
     private final <C extends CobolPreprocessor> List<C> convertAll(List<? extends ParserRuleContext>... trees) {
-        return convertAll(Arrays.stream(trees)
-                .filter(Objects::nonNull)
-                .flatMap(Collection::stream)
-                .sorted(Comparator.comparingInt(it -> it.start.getStartIndex()))
-                .collect(Collectors.toList()));
+        List<ParserRuleContext> list = new ArrayList<>();
+        for (List<? extends ParserRuleContext> tree : trees) {
+            if (tree != null) {
+                for (ParserRuleContext parserRuleContext : tree) {
+                    list.add(parserRuleContext);
+                }
+            }
+        }
+        list.sort(Comparator.comparingInt(it -> it.start.getStartIndex()));
+        return convertAll(list);
     }
 
     private <C extends CobolPreprocessor, T extends ParseTree> List<C> convertAll(List<T> trees) {
@@ -891,13 +895,22 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
 
     @SafeVarargs
     private final List<CobolPreprocessor> convertAllList(List<? extends ParseTree>... trees) {
-        return Arrays.stream(trees)
-                .flatMap(Collection::stream)
-                .filter(Objects::nonNull)
-                .sorted(Comparator.comparingInt(it -> it instanceof TerminalNode ? ((TerminalNode) it).getSymbol().getStartIndex() :
-                        ((ParserRuleContext) it).getStart().getStartIndex()))
-                .map(it -> (CobolPreprocessor) visit(it))
-                .collect(Collectors.toList());
+        List<ParseTree> toSort = new ArrayList<>();
+        for (List<? extends ParseTree> tree : trees) {
+            for (ParseTree it : tree) {
+                if (it != null) {
+                    toSort.add(it);
+                }
+            }
+        }
+        toSort.sort(Comparator.comparingInt(it -> it instanceof TerminalNode ? ((TerminalNode) it).getSymbol().getStartIndex() :
+                ((ParserRuleContext) it).getStart().getStartIndex()));
+        List<CobolPreprocessor> parsed = new ArrayList<>();
+        for (ParseTree it : toSort) {
+            CobolPreprocessor visit = (CobolPreprocessor) visit(it);
+            parsed.add(visit);
+        }
+        return parsed.isEmpty() ? emptyList() : parsed;
     }
 
     /**
@@ -911,9 +924,13 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
         sequenceArea();
         indicatorArea();
 
-        Integer nextIndicator = indicatorAreas.keySet().stream()
-                .filter(it -> it > cursor)
-                .findFirst().orElse(null);
+        Integer nextIndicator = null;
+        for (Integer integer : indicatorAreas.keySet()) {
+            if (integer > cursor) {
+                nextIndicator = integer;
+                break;
+            }
+        }
         boolean isContinued = nextIndicator != null && indicatorAreas.get(nextIndicator).equals("-");
 
         Character delimiter = null;
@@ -925,10 +942,13 @@ public class CobolPreprocessorParserVisitor extends CobolPreprocessorBaseVisitor
         // Detect a continued keyword or identifier.
         if (isContinued && delimiter == null) {
             // CommentAreas are optional text that will precede the end of line.
-            Integer nextCommentArea = commentAreas.keySet().stream()
-                    .filter(it -> it > cursor)
-                    .findFirst()
-                    .orElse(null);
+            Integer nextCommentArea = null;
+            for (Integer it : commentAreas.keySet()) {
+                if (it > cursor) {
+                    nextCommentArea = it;
+                    break;
+                }
+            }
 
             String current = source.substring(cursor);
             int newLinePos = current.indexOf("\n");


### PR DESCRIPTION
Changes:

- Replaced the use of streams in CobolPreprocessorParserVisitor and PreprocessReplaceVisitor.
- Return emptyList() in conversion methods.
